### PR TITLE
stlファイルの読み取り時に種類の判別がうまくできない問題を修正しました。

### DIFF
--- a/basis/trimesh/io/stl.py
+++ b/basis/trimesh/io/stl.py
@@ -8,6 +8,8 @@ _stl_dtype_header = np.dtype([('header', np.void, 80), ('face_count', np.int32)]
 
 
 def load_stl(file_obj, file_type=None):
+    if 'b' not in file_obj.mode:
+        raise
     if is_binary_file(file_obj):
         return load_stl_binary(file_obj)
     else:

--- a/basis/trimesh/util.py
+++ b/basis/trimesh/util.py
@@ -342,21 +342,24 @@ def tolist_dict(data):
     return result
 
 
-def is_binary_file(file_obj):
+def is_binary_file(file_obj, probe_sz=1024):
     '''
     Returns True if file has non-ASCII characters (> 0x7F, or 127)
     Should work in both Python 2 and 3
     '''
-    start = file_obj.tell()
-    fbytes = file_obj.read(1024)
-    file_obj.seek(start)
-    is_str = isinstance(fbytes, str)
-    for fbyte in fbytes:
-        if is_str:
-            code = ord(fbyte)
-        else:
-            code = fbyte
-        if code > 127: return True
+    try:
+        start = file_obj.tell()
+        fbytes = file_obj.read(probe_sz)
+        file_obj.seek(start)
+        is_str = isinstance(fbytes, str)
+        for fbyte in fbytes:
+            if is_str:
+                code = ord(fbyte)
+            else:
+                code = fbyte
+            if code > 127: return True
+    except UnicodeDecodeError:
+        return True
     return False
 
 


### PR DESCRIPTION
[FIX]
1. Catch UnicodeDecodeError
2. Assume fileio mode 'b' on stl even when reading ascii
* Please note that other file types that have both bin and text formats should also be handled in the similar way.