### PR TITLE
Remove angle range condition

### DIFF
--- a/basis/robot_math.py
+++ b/basis/robot_math.py
@@ -39,8 +39,6 @@ def rotmat_from_axangle(axis, angle):
     date: 20161220
     """
     axis = unit_vector(axis)
-    if angle > 2 * math.pi:
-        angle = angle % 2 * math.pi
     a = math.cos(angle / 2.0)
     b, c, d = -axis * math.sin(angle / 2.0)
     aa, bb, cc, dd = a * a, b * b, c * c, d * d


### PR DESCRIPTION
元のプログラムに存在した例外処理があると，バグが発生していました．
sin, cosの範囲に限りは無いようなので，消去しました．

もし，例外処理が必要ということであれば，その部分を以下のようなコードにすると良いかと思います．
```python
    if abs(angle) > 2 * math.pi:
        angle = angle % (2 * math.pi)
```