### PR TITLE
Add color texture to phoxi server

### DIFF
--- a/drivers/devices/phoxi/__init__.py
+++ b/drivers/devices/phoxi/__init__.py
@@ -1,1 +1,4 @@
-import phoxicontrol
+import os
+os.add_dll_directory("C:\Program Files\Photoneo\PhoXiControl-1.7.5\API\\bin")
+os.add_dll_directory("D:\opencv\\build\\x64\\vc14\\bin")
+import drivers.devices.phoxi.phoxicontrol

--- a/drivers/rpc/phoxi/phoxi.proto
+++ b/drivers/rpc/phoxi/phoxi.proto
@@ -6,6 +6,7 @@ service Phoxi {
     rpc getdepthimg (Empty) returns (CamImg) {}
     rpc getpcd (Empty) returns (PointCloud) {}
     rpc getnormals (Empty) returns (PointCloud) {}
+    rpc getrgbtextureimg (Empty) returns (CamImg) {}
 }
 
 message Empty {


### PR DESCRIPTION
- Add color texture to phoxi server
    - Add a new parameter `calibpath` in the constructor function of CPP code. It refers to file path of calibration matrix. It can be empty to turn off capturing color texture
    - Add new functions in CPP code
        - `loadCalibration`: load calibration matrix
        - `configExternalCam`: set up resolution parameters for external camera
        - `getColorImage`: get color image from external camera by OpenCv
        - `setColorPointCloudTexture`: generate color point cloud texture
        - `getexternalcamimg`: get the image captured by external camera (only for debug)
        - `getrgbtexture`: get the color point cloud texture
    - Add interface to get the color point cloud texture for the phoxi_server, phoxi_client and phoxi.proto